### PR TITLE
fix ResizeIframe

### DIFF
--- a/js/createResizeIframe.js
+++ b/js/createResizeIframe.js
@@ -20,8 +20,7 @@ export function createResizeIframe(site, frameId) {
 
   if (frameId[0] !== "/") frameId = "/" + frameId;
 
-  return debounce(function (receivedData) {
-    if (receivedData) flags.showInterwiki = true;
+  return debounce(function () {
     if (flags.showInterwiki) {
       // Measure from the top of the document to the iframe container to get
       // the document height - this takes into account inner margins, unlike
@@ -54,8 +53,6 @@ function debounce(func, wait) {
   var timeout = 0;
   return function () {
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
-      func(arguments);
-    }, wait);
+    timeout = setTimeout(func, wait);
   };
 }


### PR DESCRIPTION
The former `receivedData` param will always be truthy, so this may happen:
- `interwikiFrame.html` is rendered
- `ResizeObserver` set the debounced function to run after 750 ms
- the translations loading process took longer than 750 ms 
- the debounced function is called, `flags.showInterwiki` is set to true **before** any translation is loaded to page
- the `resize-iframe.html` is loaded, the height of Interwiki iframe is set to a very small value
- the translations loading process completed, call the debounced function again
- the script try to change the src of  `resize-iframe.html`, but the # hash part is ignored
- so the height of Interwiki iframe is not changed, the user can't see it

The value of `flags.showInterwiki` is already shared in https://github.com/SCP-CN-Tech/Interwiki/commit/8e1527f33dc731d08be69876da8d89ccbcbe7b93
so we can just use it directly here to prevent `resize-iframe.html` from be loaded when the page init